### PR TITLE
Client fixes and refactoring

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -31,7 +31,6 @@ function App({ pca }: AppProps) {
         <div>
           <Routes>
             {Object.values(routes).map((route, index) => {
-              console.log(index);
               if (route.requiresLogin) {
                 return (
                   <Route

--- a/client/src/pages/organizations/createOrganization.tsx
+++ b/client/src/pages/organizations/createOrganization.tsx
@@ -1,7 +1,7 @@
 import React, { ChangeEvent, useState } from "react";
 import { useNavigate } from "react-router";
 import { Button, Divider, Form, Header, Message } from "semantic-ui-react";
-import { useCreateOrganizationMutation } from "../../slices/runners/runners-api-slice";
+import { useCreateOrganizationMutation } from "../../slices/runners/raceresults-api-slice";
 import BasePage from "../../utils/basePage";
 import routes from "../../utils/routes";
 
@@ -27,7 +27,7 @@ const CreateOrganizationPage = () => {
     createOrganization({ name: name })
       .unwrap()
       .then((createdOrg) =>
-        navigate(routes.organizations.createPath(createdOrg.id))
+        navigate(routes.organization.createPath(createdOrg.id))
       )
       .catch(() => setError(true));
   };

--- a/client/src/pages/organizations/organization.tsx
+++ b/client/src/pages/organizations/organization.tsx
@@ -4,7 +4,7 @@ import { Divider, Header, Table } from "semantic-ui-react";
 import {
   useFetchMembersQuery,
   useFetchOrganizationQuery
-} from "../../slices/runners/runners-api-slice";
+} from "../../slices/runners/raceresults-api-slice";
 import BasePage from "../../utils/basePage";
 import { LoadingOrError } from "../../utils/loadingOrError";
 import NotFound from "../notFound";

--- a/client/src/pages/organizations/organizations.tsx
+++ b/client/src/pages/organizations/organizations.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { NavLink } from "react-router-dom";
 import { Button, Divider, Header, List } from "semantic-ui-react";
-import { useFetchOrganizationsQuery } from "../../slices/runners/runners-api-slice";
+import { useFetchOrganizationsQuery } from "../../slices/runners/raceresults-api-slice";
 import BasePage from "../../utils/basePage";
 import { LoadingOrError } from "../../utils/loadingOrError";
 import routes from "../../utils/routes";

--- a/client/src/redux/store.ts
+++ b/client/src/redux/store.ts
@@ -1,16 +1,16 @@
 import { configureStore } from "@reduxjs/toolkit";
-import { runnersApiSlice } from "../slices/runners/runners-api-slice";
+import { raceResultsApiSlice } from "../slices/runners/raceresults-api-slice";
 
 export const store = configureStore({
   reducer: {
-    [runnersApiSlice.reducerPath]: runnersApiSlice.reducer
+    [raceResultsApiSlice.reducerPath]: raceResultsApiSlice.reducer
   },
   middleware: (getDefaultMiddleware) => {
     /*
     * This is where we can add a bunch of API-specific middleware
     */
     return getDefaultMiddleware()
-      .concat(runnersApiSlice.middleware);
+      .concat(raceResultsApiSlice.middleware);
   }
 });
 

--- a/client/src/slices/runners/raceresults-api-slice.ts
+++ b/client/src/slices/runners/raceresults-api-slice.ts
@@ -15,8 +15,8 @@ interface Organization {
   name: string;
 }
 
-export const runnersApiSlice = createApi({
-  reducerPath: "runnersApi",
+export const raceResultsApiSlice = createApi({
+  reducerPath: "raceResultsApi",
   baseQuery: fetchBaseQuery({
     baseUrl: import.meta.env.VITE_API_URL,
     prepareHeaders: async(headers) => {
@@ -39,6 +39,7 @@ export const runnersApiSlice = createApi({
       return headers;
     }
   }),
+  tagTypes: ["Organization"],
   endpoints(builder) {
     return {
       fetchOrganization: builder.query<Organization, string>({
@@ -49,14 +50,16 @@ export const runnersApiSlice = createApi({
       fetchOrganizations: builder.query<Organization[], void>({
         query() {
           return "/organizations";
-        }
+        },
+        providesTags: ["Organization"]
       }),
       createOrganization: builder.mutation<Organization, Partial<Organization>>({
         query: (post) => ({
           url: "/organizations",
           method: "POST",
           body: post
-        })
+        }),
+        invalidatesTags: ["Organization"]
       }),
       fetchMembers: builder.query<Member[], string>({
         query(orgId) {
@@ -67,4 +70,4 @@ export const runnersApiSlice = createApi({
   }
 });
 
-export const { useFetchMembersQuery, useFetchOrganizationQuery, useFetchOrganizationsQuery, useCreateOrganizationMutation } = runnersApiSlice;
+export const { useFetchMembersQuery, useFetchOrganizationQuery, useFetchOrganizationsQuery, useCreateOrganizationMutation } = raceResultsApiSlice;


### PR DESCRIPTION
1. Rename `runners-api-slice` to `raceresults-api-slice`
2. Remove some debug console logs
3. Invalidate `/organizations` cache after creating a new org
4. Redirect to the created organization page instead of `/organizations`