### PR TITLE
Add checkpoint models and generate newsletter pane

### DIFF
--- a/api/src/API/Controllers/SubmissionCheckpointsController.cs
+++ b/api/src/API/Controllers/SubmissionCheckpointsController.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using RaceResults.Api.Authorization;
+using RaceResults.Api.Parameters;
+using RaceResults.Common.Models;
+using RaceResults.Data.Core;
+
+namespace RaceResults.Api.Controllers
+{
+    [Authorize]
+    [ApiController]
+    [Route("organizations/{orgId}/submissionCheckpoints")]
+    public class SubmissionCheckpointsController : ControllerBase
+    {
+        private readonly ICosmosDbContainerProvider containerProvider;
+
+        private readonly ILogger<SubmissionCheckpointsController> logger;
+
+        public SubmissionCheckpointsController(
+                ICosmosDbContainerProvider cosmosDbContainerProvider,
+                ILogger<SubmissionCheckpointsController> logger)
+        {
+            this.containerProvider = cosmosDbContainerProvider;
+            this.logger = logger;
+        }
+
+        [HttpGet]
+        [ServiceFilter(typeof(RequireOrganizationAuthorizationAttribute))]
+        public async Task<IActionResult> GetSubmissionCheckpoints([OrganizationId] string orgId)
+        {
+            SubmissionCheckpointContainerClient container = containerProvider.SubmissionCheckpointContainer;
+            IEnumerable<SubmissionCheckpoint> result = await container.GetAllSubmissionCheckpointsAsync(orgId);
+            return Ok(result);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> CreateSubmissionCheckpoint(string orgId, SubmissionCheckpoint checkpoint)
+        {
+            if (checkpoint.OrganizationId != Guid.Parse(orgId))
+            {
+                return BadRequest();
+            }
+
+            SubmissionCheckpointContainerClient container = containerProvider.SubmissionCheckpointContainer;
+            var addedCheckpoint = await container.AddOneAsync(checkpoint);
+            return CreatedAtAction(nameof(CreateSubmissionCheckpoint), new { id = addedCheckpoint.Id }, addedCheckpoint);
+        }
+    }
+}

--- a/api/src/Common/Models/SubmissionCheckpoint.cs
+++ b/api/src/Common/Models/SubmissionCheckpoint.cs
@@ -1,0 +1,21 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace RaceResults.Common.Models
+{
+    public struct SubmissionCheckpoint : IModel
+    {
+        public Guid Id { get; set; }
+
+        [Required]
+        public Guid OrganizationId { get; set; }
+
+        [Required]
+        public DateTime Checkpointed { get; set; }
+
+        public string GetPartitionKey()
+        {
+            return OrganizationId.ToString();
+        }
+    }
+}

--- a/api/src/Data/Core/ContainerClients/SubmissionCheckpointContainerClient.cs
+++ b/api/src/Data/Core/ContainerClients/SubmissionCheckpointContainerClient.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using RaceResults.Common.Exceptions;
+using RaceResults.Common.Models;
+
+namespace RaceResults.Data.Core
+{
+    public class SubmissionCheckpointContainerClient : ContainerClient<SubmissionCheckpoint>
+    {
+        public SubmissionCheckpointContainerClient(ICosmosDbClient cosmosDbClient)
+            : base(cosmosDbClient.GetContainer(ContainerConstants.SubmissionCheckpointContainerName))
+        {
+        }
+
+        public async Task<IEnumerable<SubmissionCheckpoint>> GetAllSubmissionCheckpointsAsync(string orgId)
+        {
+            var orgGuid = Guid.Parse(orgId);
+            return await this.GetManyAsync(it => it.Where(checkpoint => checkpoint.OrganizationId == orgGuid));
+        }
+    }
+}

--- a/api/src/Data/Core/ContainerConstants.cs
+++ b/api/src/Data/Core/ContainerConstants.cs
@@ -15,5 +15,7 @@ namespace RaceResults.Data.Core
         public const string RaceResultContainerName = "RaceResultContainer";
 
         public const string MemberMatchRecordContainerName = "MemberMatchRecordContainer";
+
+        public const string SubmissionCheckpointContainerName = "SubmissionCheckpointContainer";
     }
 }

--- a/api/src/Data/Core/CosmosDbContainerProvider.cs
+++ b/api/src/Data/Core/CosmosDbContainerProvider.cs
@@ -10,6 +10,8 @@ namespace RaceResults.Data.Core
 
         public MemberContainerClient MemberContainer { get; }
 
+        public SubmissionCheckpointContainerClient SubmissionCheckpointContainer { get; }
+
         public OrganizationContainerClient OrganizationContainer { get; }
 
         public AuthContainerClient<RaceResultsAuth> RaceResultsAuthContainer { get; }
@@ -23,6 +25,8 @@ namespace RaceResults.Data.Core
             this.RaceContainer = new RaceContainerClient(cosmosDbClient);
 
             this.MemberContainer = new MemberContainerClient(cosmosDbClient);
+
+            this.SubmissionCheckpointContainer = new SubmissionCheckpointContainerClient(cosmosDbClient);
 
             this.OrganizationContainer = new OrganizationContainerClient(cosmosDbClient);
 

--- a/api/src/Data/Core/ICosmosDbContainerProvider.cs
+++ b/api/src/Data/Core/ICosmosDbContainerProvider.cs
@@ -10,6 +10,8 @@ namespace RaceResults.Data.Core
 
         MemberContainerClient MemberContainer { get; }
 
+        SubmissionCheckpointContainerClient SubmissionCheckpointContainer { get; }
+
         OrganizationContainerClient OrganizationContainer { get; }
 
         AuthContainerClient<RaceResultsAuth> RaceResultsAuthContainer { get; }

--- a/api/tests/API/Tests/Controllers/MembersControllerTests.cs
+++ b/api/tests/API/Tests/Controllers/MembersControllerTests.cs
@@ -64,6 +64,7 @@ namespace Internal.Api.Tests
             MockCosmosDbClient cosmosDbClient = new MockCosmosDbClient();
             cosmosDbClient.AddNewContainer(ContainerConstants.MemberContainerName, memberContainer);
             cosmosDbClient.AddEmptyOrganizationContainer();
+            cosmosDbClient.AddEmptySubmissionCheckpointContainer();
             cosmosDbClient.AddEmptyRaceContainer();
             cosmosDbClient.AddEmptyRaceResultAuthContainer();
             cosmosDbClient.AddEmptyWildApricotAuthContainer();

--- a/api/tests/API/Tests/Controllers/OrganizationsControllerTests.cs
+++ b/api/tests/API/Tests/Controllers/OrganizationsControllerTests.cs
@@ -55,6 +55,7 @@ namespace Internal.Api.Tests
             cosmosDbClient.AddEmptyRaceResultAuthContainer();
             cosmosDbClient.AddEmptyWildApricotAuthContainer();
             cosmosDbClient.AddEmptyRaceResultContainer();
+            cosmosDbClient.AddEmptySubmissionCheckpointContainer();
 
             ICosmosDbContainerProvider provider = new CosmosDbContainerProvider(cosmosDbClient);
             controller = new OrganizationsController(provider, keyVaultClient, NullLogger<OrganizationsController>.Instance);

--- a/api/tests/API/Tests/Controllers/RaceResultsControllerTests.cs
+++ b/api/tests/API/Tests/Controllers/RaceResultsControllerTests.cs
@@ -135,6 +135,7 @@ namespace Internal.Api.Tests
             MockCosmosDbClient cosmosDbClient = new MockCosmosDbClient();
             cosmosDbClient.AddNewContainer(ContainerConstants.MemberContainerName, memberContainer);
             cosmosDbClient.AddEmptyOrganizationContainer();
+            cosmosDbClient.AddEmptySubmissionCheckpointContainer();
             cosmosDbClient.AddEmptyRaceResultAuthContainer();
             cosmosDbClient.AddEmptyWildApricotAuthContainer();
             cosmosDbClient.AddNewContainer(ContainerConstants.RaceContainerName, raceContainer);

--- a/api/tests/API/Tests/Controllers/RacesControllerTests.cs
+++ b/api/tests/API/Tests/Controllers/RacesControllerTests.cs
@@ -59,6 +59,7 @@ namespace Internal.Api.Tests
             cosmosDbClient.AddEmptyOrganizationContainer();
             cosmosDbClient.AddNewContainer(ContainerConstants.RaceContainerName, raceContainer);
             cosmosDbClient.AddEmptyRaceResultContainer();
+            cosmosDbClient.AddEmptySubmissionCheckpointContainer();
 
             ICosmosDbContainerProvider provider = new CosmosDbContainerProvider(cosmosDbClient);
             controller = new RacesController(provider, NullLogger<RacesController>.Instance);

--- a/api/tests/API/Tests/Controllers/RacesControllerTests.cs
+++ b/api/tests/API/Tests/Controllers/RacesControllerTests.cs
@@ -57,9 +57,9 @@ namespace Internal.Api.Tests
             cosmosDbClient.AddEmptyRaceResultAuthContainer();
             cosmosDbClient.AddEmptyWildApricotAuthContainer();
             cosmosDbClient.AddEmptyOrganizationContainer();
+            cosmosDbClient.AddEmptySubmissionCheckpointContainer();
             cosmosDbClient.AddNewContainer(ContainerConstants.RaceContainerName, raceContainer);
             cosmosDbClient.AddEmptyRaceResultContainer();
-            cosmosDbClient.AddEmptySubmissionCheckpointContainer();
 
             ICosmosDbContainerProvider provider = new CosmosDbContainerProvider(cosmosDbClient);
             controller = new RacesController(provider, NullLogger<RacesController>.Instance);

--- a/api/tests/Data/Tests/Core/CosmosDbContainerProviderTests.cs
+++ b/api/tests/Data/Tests/Core/CosmosDbContainerProviderTests.cs
@@ -15,6 +15,7 @@ namespace Internal.Data.Tests
         {
             Container memberContainer = MockContainerProvider<Member>.CreateMockContainer(new List<Member>());
             Container organizationContainer = MockContainerProvider<Organization>.CreateMockContainer(new List<Organization>());
+            Container submissionCheckpointContainer = MockContainerProvider<SubmissionCheckpoint>.CreateMockContainer(new List<SubmissionCheckpoint>());
             Container raceContainer = MockContainerProvider<Race>.CreateMockContainer(new List<Race>());
             Container raceResultContainer = MockContainerProvider<RaceResult>.CreateMockContainer(new List<RaceResult>());
             Container raceResultAuthContainer = MockContainerProvider<RaceResultsAuth>.CreateMockContainer(new List<RaceResultsAuth>());
@@ -24,6 +25,7 @@ namespace Internal.Data.Tests
 
             cosmosDbClient.AddNewContainer(ContainerConstants.MemberContainerName, memberContainer);
             cosmosDbClient.AddNewContainer(ContainerConstants.OrganizationContainerName, organizationContainer);
+            cosmosDbClient.AddNewContainer(ContainerConstants.SubmissionCheckpointContainerName, submissionCheckpointContainer);
             cosmosDbClient.AddNewContainer(ContainerConstants.RaceContainerName, raceContainer);
             cosmosDbClient.AddNewContainer(ContainerConstants.RaceResultContainerName, raceResultContainer);
             cosmosDbClient.AddNewContainer(ContainerConstants.RaceResultsAuthContainerName, raceResultAuthContainer);

--- a/api/tests/Data/Utils/MockCosmosDbClient.cs
+++ b/api/tests/Data/Utils/MockCosmosDbClient.cs
@@ -38,6 +38,12 @@ namespace Internal.Data.Utils
             this.AddNewContainer(ContainerConstants.MemberContainerName, memberContainer);
         }
 
+        public void AddEmptySubmissionCheckpointContainer()
+        {
+            Container raceResultContainer = MockContainerProvider<SubmissionCheckpoint>.CreateMockContainer(new List<SubmissionCheckpoint>());
+            this.AddNewContainer(ContainerConstants.SubmissionCheckpointContainerName, raceResultContainer);
+        }
+
         public void AddEmptyOrganizationContainer()
         {
             Container organizationContainer = MockContainerProvider<Organization>.CreateMockContainer(new List<Organization>());

--- a/client/src/pages/organization/index.tsx
+++ b/client/src/pages/organization/index.tsx
@@ -2,12 +2,16 @@ import React from "react";
 import { useLocation, useNavigate, useParams } from "react-router";
 import { useSearchParams } from "react-router-dom";
 import { Divider, Header, Tab, TabProps } from "semantic-ui-react";
-import { useFetchOrganizationQuery } from "../../slices/runners/raceresults-api-slice";
+import {
+  Organization,
+  useFetchOrganizationQuery,
+} from "../../slices/runners/raceresults-api-slice";
 import BasePage from "../../utils/basePage";
 import { LoadingOrError } from "../../utils/loadingOrError";
 import NotFound from "../notFound";
 import LinksPane from "./linksPane";
 import MembersPane from "./membersPane";
+import NewsletterPane from "./newsletterPane";
 import RacesPane from "./racesPane";
 import SubmissionsPane from "./submissionsPane";
 
@@ -52,6 +56,14 @@ const OrganizationPage = () => {
         render: () => (
           <Tab.Pane>
             <LinksPane orgId={id} />
+          </Tab.Pane>
+        ),
+      },
+      {
+        menuItem: "Newsletters",
+        render: () => (
+          <Tab.Pane>
+            <NewsletterPane organization={orgResponse.data as Organization} />
           </Tab.Pane>
         ),
       },

--- a/client/src/pages/organization/newsletterPane.tsx
+++ b/client/src/pages/organization/newsletterPane.tsx
@@ -1,0 +1,197 @@
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  Button,
+  Dimmer,
+  Form,
+  Loader,
+  Modal,
+  TextArea,
+} from "semantic-ui-react";
+import {
+  Organization,
+  RaceResponse,
+  RaceResultResponse,
+  useCreateSubmissionCheckpointMutation,
+  useFetchSubmissionCheckpointsQuery,
+  useLazyFetchRaceResultsQuery,
+} from "../../slices/runners/raceresults-api-slice";
+import { LoadingOrError } from "../../utils/loadingOrError";
+import RequireOrganizationLogin from "../organizations/raceResults/RequireOrganizationLogin";
+
+interface NewsletterPaneProps {
+  organization: Organization;
+}
+
+const NewsletterPane = (props: NewsletterPaneProps) => {
+  const [createCheckpoint] = useCreateSubmissionCheckpointMutation();
+
+  const checkpointsResponse = useFetchSubmissionCheckpointsQuery({
+    orgId: props.organization.id,
+  });
+  const [
+    fetchRaceResults,
+    raceResultsResponse,
+  ] = useLazyFetchRaceResultsQuery();
+
+  useEffect(() => {
+    if (
+      checkpointsResponse.isFetching ||
+      checkpointsResponse.isLoading ||
+      checkpointsResponse.data === undefined
+    ) {
+      return;
+    }
+
+    const checkpoints = checkpointsResponse.data.map(
+      (resp) => new Date(Date.parse(resp.checkpointed))
+    );
+    const mostRecentCheckpoint =
+      checkpoints.length > 0
+        ? checkpoints.sort()[checkpoints.length - 1].toISOString()
+        : null;
+
+    fetchRaceResults({
+      orgId: props.organization.id,
+      startDate: mostRecentCheckpoint,
+      endDate: null,
+    });
+  }, [checkpointsResponse.data]);
+
+  const [generating, setGenerating] = useState(false);
+  const [generated, setGenerated] = useState(false);
+  const [newsletterText, setNewsletterText] = useState("");
+
+  const createNewsletter = useCallback(() => {
+    if (raceResultsResponse.data === undefined) {
+      return;
+    }
+
+    setGenerating(true);
+
+    const racesByEvent = new Map<string, RaceResponse[]>();
+    const submissionsByRace = new Map<string, RaceResultResponse[]>();
+    raceResultsResponse.data.forEach((result) => {
+      const race = result.race;
+      if (race === null) {
+        return;
+      }
+
+      if (racesByEvent.has(race.eventId)) {
+        racesByEvent.get(race.eventId)?.push(race);
+      } else {
+        racesByEvent.set(race.eventId, [race]);
+      }
+
+      if (submissionsByRace.has(race.id)) {
+        submissionsByRace.get(race.id)?.push(result);
+      } else {
+        submissionsByRace.set(race.id, [result]);
+      }
+    });
+
+    const eventStrings: string[] = [];
+    racesByEvent.forEach((races) => {
+      const raceForInfo = races[0];
+
+      const multipleDistances = races.length > 1;
+      const raceStrings: string[] = [];
+      races.forEach((race) => {
+        const submissionStrings: string[] = [];
+        submissionsByRace.get(race.id)?.forEach((submission) => {
+          let text = `• ${submission.member?.firstName} ${submission.member?.lastName} ran a time of ${submission.raceResult.time}.`;
+          if (submission.raceResult.comments !== "") {
+            text = text + ` They said "${submission.raceResult.comments}".`;
+          }
+          submissionStrings.push(text);
+        });
+
+        const submissionsList = submissionStrings
+          .map((t) => `\t${t}`)
+          .join("\n");
+
+        const text = multipleDistances
+          ? `For the ${race.distance} race:
+${submissionsList}`
+          : submissionsList;
+        raceStrings.push(text);
+      });
+
+      const distanceText = multipleDistances
+        ? ""
+        : `a ${raceForInfo.distance} race`;
+
+      const eventText = `We had members run ${distanceText} at ${
+        raceForInfo.name
+      } on ${new Date(Date.parse(raceForInfo.date)).toDateString()}.
+${raceStrings.join("\n")}`;
+
+      eventStrings.push(eventText);
+    });
+
+    const newsletterText = eventStrings.join("\n\n");
+    setNewsletterText(newsletterText);
+
+    setGenerating(false);
+    setGenerated(true);
+  }, [raceResultsResponse.data]);
+
+  return (
+    <RequireOrganizationLogin organization={props.organization}>
+      <LoadingOrError
+        isLoading={
+          checkpointsResponse.isLoading || raceResultsResponse.isLoading
+        }
+        hasError={checkpointsResponse.isError || raceResultsResponse.isError}
+      >
+        <Dimmer active={generating} inverted>
+          <Loader inverted>Generating...</Loader>
+        </Dimmer>
+
+        <Form>
+          <TextArea
+            value={newsletterText}
+            placeholder="Click generate below to create a new newsletter."
+          />
+        </Form>
+
+        <br />
+
+        <Button primary onClick={createNewsletter} disabled={generating}>
+          Generate newsletter from submissions since last checkpoint
+        </Button>
+
+        <br />
+        <br />
+
+        <Modal
+          trigger={
+            <Button
+              content="Create checkpoint"
+              disabled={generating || !generated}
+            />
+          }
+          header="Confirm Create Checkpoint"
+          content="Are you sure you want to create a submissions checkpoint? This will reset the submissions members see after they submit a new race result, and prevent you from generating a newsletter for the submissions above. MAKE SURE YOU COPY THE NEWSLETTER ABOVE BEFORE DOING THIS."
+          actions={[
+            "Cancel",
+            {
+              key: "confirm",
+              content: "Create",
+              primary: true,
+              onClick: () =>
+                createCheckpoint({
+                  orgId: props.organization.id,
+                  checkpoint: {
+                    checkpointed: new Date(Date.now()).toISOString(),
+                    organizationId: props.organization.id,
+                  },
+                }),
+            },
+          ]}
+        />
+      </LoadingOrError>
+    </RequireOrganizationLogin>
+  );
+};
+
+export default NewsletterPane;


### PR DESCRIPTION
The primary purpose of this PR is to add the "newsletter" pane to the admin view that lets us generate a newsletter based on submissions.

To make picking submissions easier, I've opted to create a "submissions checkpoint" model. These models are just a date timestamp that mark "checkpoints" in submissions. They're primarily going to be used to mark when we create newsletters.

The newsletter generator will use all submissions added after the most recent checkpoint. The newsletter page has a button to create a new checkpoint.